### PR TITLE
Update responses

### DIFF
--- a/biit_server/account_handler.py
+++ b/biit_server/account_handler.py
@@ -37,7 +37,13 @@ def account_post(request):
     account_db = Database("accounts")
 
     try:
-        account_db.add(body, id=body["email"])
+        db_entry = {
+            "fname": body["fname"],
+            "lname": body["lname"],
+            "email": body["email"],
+        }
+
+        account_db.add(db_entry, id=body["email"])
     except:
         return http400("Email already taken")
 

--- a/biit_server/account_handler.py
+++ b/biit_server/account_handler.py
@@ -55,7 +55,7 @@ def account_post(request):
         "refresh_token": auth[1],
     }
 
-    return jsonHttp200("Account Created", response.items())
+    return jsonHttp200("Account Created", response)
 
 
 def account_get(request):
@@ -124,7 +124,9 @@ def account_put(request):
 
     try:
         account_db.update(args["email"], args["updateFields"])
-        return jsonHttp200("Account Updated", auth)
+        return jsonHttp200(
+            "Account Updated", {"access_token": auth[0], "refresh_token": auth[1]}
+        )
     except:
         return http400("Account update error")
 

--- a/biit_server/account_handler.py
+++ b/biit_server/account_handler.py
@@ -17,7 +17,7 @@ def account_post(request):
     Raises:
         Http 400 when the json is missing a key
     """
-    fields = ["fname", "lname", "email"]
+    fields = ["fname", "lname", "email", "token"]
     body = None
 
     try:
@@ -30,7 +30,10 @@ def account_post(request):
     if body_validation[1] != 200:
         return body_validation
 
-    # TODO @Ryan Create the DB stuff
+    auth = azure_refresh_token(body["token"])
+    if not auth[0]:
+        return http400("Not Authenticated")
+
     account_db = Database("accounts")
 
     try:
@@ -38,11 +41,15 @@ def account_post(request):
     except:
         return http400("Email already taken")
 
-    return http200("Account Created")
+    response = {
+        "fname": body["fname"],
+        "lname": body["lname"],
+        "email": body["email"],
+        "access_token": auth[0],
+        "refresh_token": auth[1],
+    }
 
-    # TODO uncomment once the DB is implemented
-    # this was commented out for testing purposes
-    # return http400("Failed to create account")
+    return jsonHttp200("Account Created", response)
 
 
 def account_get(request):

--- a/biit_server/account_handler.py
+++ b/biit_server/account_handler.py
@@ -55,7 +55,7 @@ def account_post(request):
         "refresh_token": auth[1],
     }
 
-    return jsonHttp200("Account Created", response)
+    return jsonHttp200("Account Created", response.items())
 
 
 def account_get(request):

--- a/biit_server/ban_handler.py
+++ b/biit_server/ban_handler.py
@@ -37,7 +37,10 @@ def ban_post(request):
     # return ban.add(args)
 
     # TODO remove once db is implemented
-    return jsonHttp200(body["bannee"] + " has been banned", {'access_token': auth[0], 'refresh_token': auth[1]})
+    return jsonHttp200(
+        body["bannee"] + " has been banned",
+        {"access_token": auth[0], "refresh_token": auth[1]},
+    )
 
 
 def ban_put(request):
@@ -72,4 +75,7 @@ def ban_put(request):
     # return ban.remove(args)
 
     # TODO remove once db is implemented
-    return jsonHttp200(args["bannee"] + " has been unbanned", {'access_token': auth[0], 'refresh_token': auth[1]})
+    return jsonHttp200(
+        args["bannee"] + " has been unbanned",
+        {"access_token": auth[0], "refresh_token": auth[1]},
+    )

--- a/biit_server/ban_handler.py
+++ b/biit_server/ban_handler.py
@@ -37,7 +37,7 @@ def ban_post(request):
     # return ban.add(args)
 
     # TODO remove once db is implemented
-    return jsonHttp200(body["bannee"] + " has been banned", auth)
+    return jsonHttp200(body["bannee"] + " has been banned", {'access_token': auth[0], 'refresh_token': auth[1]})
 
 
 def ban_put(request):
@@ -72,4 +72,4 @@ def ban_put(request):
     # return ban.remove(args)
 
     # TODO remove once db is implemented
-    return jsonHttp200(args["bannee"] + " has been unbanned", auth)
+    return jsonHttp200(args["bannee"] + " has been unbanned", {'access_token': auth[0], 'refresh_token': auth[1]})

--- a/biit_server/community_handler.py
+++ b/biit_server/community_handler.py
@@ -36,7 +36,9 @@ def community_post(request):
     # TODO @Ryan Create the DB stuff
     # if community.create(body):
 
-    return jsonHttp200("Community Created", {'access_token': auth[0], 'refresh_token': auth[1] })
+    return jsonHttp200(
+        "Community Created", {"access_token": auth[0], "refresh_token": auth[1]}
+    )
 
     # TODO uncomment once the DB is implemented
     # this was commented out for testing purposes
@@ -103,7 +105,9 @@ def community_put(request):
     # return community.update(args)
 
     # TODO remove once db is implemented
-    return jsonHttp200("Community Updated", {'access_token': auth[0], 'refresh_token': auth[1] } )
+    return jsonHttp200(
+        "Community Updated", {"access_token": auth[0], "refresh_token": auth[1]}
+    )
 
 
 def community_delete(request):
@@ -137,7 +141,9 @@ def community_delete(request):
     # return community.delete(args)
 
     # TODO remove once db is implemented
-    return jsonHttp200("Community Deleted", {'access_token': auth[0], 'refresh_token': auth[1] } )
+    return jsonHttp200(
+        "Community Deleted", {"access_token": auth[0], "refresh_token": auth[1]}
+    )
 
 
 def community_join_post(request, community_id):
@@ -172,7 +178,9 @@ def community_join_post(request, community_id):
 
     # TODO @Ryan Create the DB stuff
     # if community.join(body,community_id):
-    return jsonHttp200("Community Joined", {'access_token': auth[0], 'refresh_token': auth[1] } )
+    return jsonHttp200(
+        "Community Joined", {"access_token": auth[0], "refresh_token": auth[1]}
+    )
 
     # TODO uncomment once the DB is implemented
     # this was commented out for testing purposes
@@ -210,7 +218,9 @@ def community_leave_post(request, community_id):
 
     # TODO @Ryan Create the DB stuff
     # if community.join(body,community_id):
-    return jsonHttp200("Community Left", {'access_token': auth[0], 'refresh_token': auth[1] } )
+    return jsonHttp200(
+        "Community Left", {"access_token": auth[0], "refresh_token": auth[1]}
+    )
 
     # TODO uncomment once the DB is implemented
     # this was commented out for testing purposes

--- a/biit_server/community_handler.py
+++ b/biit_server/community_handler.py
@@ -103,7 +103,7 @@ def community_put(request):
     # return community.update(args)
 
     # TODO remove once db is implemented
-    return jsonHttp200("Community Updated", auth)
+    return jsonHttp200("Community Updated", {'access_token': auth[0], 'refresh_token': auth[1] } )
 
 
 def community_delete(request):
@@ -137,7 +137,7 @@ def community_delete(request):
     # return community.delete(args)
 
     # TODO remove once db is implemented
-    return jsonHttp200("Community Deleted", auth)
+    return jsonHttp200("Community Deleted", {'access_token': auth[0], 'refresh_token': auth[1] } )
 
 
 def community_join_post(request, community_id):
@@ -172,7 +172,7 @@ def community_join_post(request, community_id):
 
     # TODO @Ryan Create the DB stuff
     # if community.join(body,community_id):
-    return jsonHttp200("Community Joined", auth)
+    return jsonHttp200("Community Joined", {'access_token': auth[0], 'refresh_token': auth[1] } )
 
     # TODO uncomment once the DB is implemented
     # this was commented out for testing purposes
@@ -210,7 +210,7 @@ def community_leave_post(request, community_id):
 
     # TODO @Ryan Create the DB stuff
     # if community.join(body,community_id):
-    return jsonHttp200("Community Left", auth)
+    return jsonHttp200("Community Left", {'access_token': auth[0], 'refresh_token': auth[1] } )
 
     # TODO uncomment once the DB is implemented
     # this was commented out for testing purposes

--- a/biit_server/community_handler.py
+++ b/biit_server/community_handler.py
@@ -36,7 +36,7 @@ def community_post(request):
     # TODO @Ryan Create the DB stuff
     # if community.create(body):
 
-    return jsonHttp200("Community Created", auth)
+    return jsonHttp200("Community Created", {'access_token': auth[0], 'refresh_token': auth[1] })
 
     # TODO uncomment once the DB is implemented
     # this was commented out for testing purposes

--- a/biit_server/http_responses.py
+++ b/biit_server/http_responses.py
@@ -1,5 +1,5 @@
 from flask import jsonify
-
+from typing import Dict, Any
 
 def http405():
     return "Method not allowed", 405
@@ -15,7 +15,7 @@ def http200(description: str = ""):
     return f"OK: {description}", 200
 
 
-def jsonHttp200(message: str, data: dict):
+def jsonHttp200(message: str, data: Dict[str, Any]):
     """Http 200 response with json as data
 
     Args:

--- a/biit_server/http_responses.py
+++ b/biit_server/http_responses.py
@@ -15,7 +15,7 @@ def http200(description: str = ""):
     return f"OK: {description}", 200
 
 
-def jsonHttp200(message: str, data):
+def jsonHttp200(message: str, data: dict):
     """Http 200 response with json as data
 
     Args:
@@ -25,6 +25,7 @@ def jsonHttp200(message: str, data):
     Returns:
         str: Json combination of data and message
     """
-    json = list(data)
-    json.append(message)
-    return jsonify(json)
+    response = data
+    response['message'] = message
+    response['status_code'] = 200
+    return jsonify(response)

--- a/biit_server/http_responses.py
+++ b/biit_server/http_responses.py
@@ -1,6 +1,7 @@
 from flask import jsonify
 from typing import Dict, Any
 
+
 def http405():
     return "Method not allowed", 405
 
@@ -26,6 +27,6 @@ def jsonHttp200(message: str, data: Dict[str, Any]):
         str: Json combination of data and message
     """
     response = data
-    response['message'] = message
-    response['status_code'] = 200
+    response["message"] = message
+    response["status_code"] = 200
     return jsonify(response)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -22,15 +22,31 @@ def test_account_post(client):
     TODO this test needs to be modified when the database is connected
     """
 
-    with patch("biit_server.account_handler.Database") as mock_database:
+    with patch.object(
+        account_handler, "azure_refresh_token"
+    ) as mock_azure_refresh_token, patch(
+        "biit_server.account_handler.Database"
+    ) as mock_database:
         instance = mock_database.return_value
         instance.add.return_value = True
+        mock_azure_refresh_token.return_value = (
+            "yessir a new access token",
+            "yes a new refresh token",
+        )
         rv = client.post(
             "/account",
-            json={"fname": "first", "lname": "last", "email": "test@email.com"},
+            json={
+                "fname": "first",
+                "lname": "last",
+                "email": "test@email.com",
+                "token": "ah a testing refresh token",
+            },
             follow_redirects=True,
         )
-        assert b"OK: Account Created" == rv.data
+        assert (
+            b'["fname","lname","email","access_token","refresh_token","Account Created"]\n'
+            == rv.data
+        )
 
 
 def test_account_get(client):

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -44,7 +44,7 @@ def test_account_post(client):
             follow_redirects=True,
         )
         assert (
-            b'["fname","lname","email","access_token","refresh_token","Account Created"]\n'
+            b'{"access_token":"yessir a new access token","email":"test@email.com","fname":"first","lname":"last","message":"Account Created","refresh_token":"yes a new refresh token","status_code":200}\n'
             == rv.data
         )
 
@@ -96,7 +96,10 @@ def test_account_put(client):
             },
             follow_redirects=True,
         )
-        assert b'["RefreshToken","AccessToken","Account Updated"]\n' == rv.data
+        assert (
+            b'{"access_token":"RefreshToken","message":"Account Updated","refresh_token":"AccessToken","status_code":200}\n'
+            == rv.data
+        )
 
 
 def test_account_delete(client):

--- a/tests/test_ban.py
+++ b/tests/test_ban.py
@@ -29,7 +29,10 @@ def test_ban_post(client):
             },
             follow_redirects=True,
         )
-        assert b'{"access_token":"RefreshToken","message":"last has been banned","refresh_token":"AccessToken","status_code":200}\n' == rv.data
+        assert (
+            b'{"access_token":"RefreshToken","message":"last has been banned","refresh_token":"AccessToken","status_code":200}\n'
+            == rv.data
+        )
 
 
 def test_ban_put(client):
@@ -50,4 +53,7 @@ def test_ban_put(client):
             },
             follow_redirects=True,
         )
-        assert b'{"access_token":"RefreshToken","message":"last has been unbanned","refresh_token":"AccessToken","status_code":200}\n' == rv.data
+        assert (
+            b'{"access_token":"RefreshToken","message":"last has been unbanned","refresh_token":"AccessToken","status_code":200}\n'
+            == rv.data
+        )

--- a/tests/test_ban.py
+++ b/tests/test_ban.py
@@ -29,7 +29,7 @@ def test_ban_post(client):
             },
             follow_redirects=True,
         )
-        assert b'["RefreshToken","AccessToken","last has been banned"]\n' == rv.data
+        assert b'{"access_token":"RefreshToken","message":"last has been banned","refresh_token":"AccessToken","status_code":200}\n' == rv.data
 
 
 def test_ban_put(client):
@@ -50,4 +50,4 @@ def test_ban_put(client):
             },
             follow_redirects=True,
         )
-        assert b'["RefreshToken","AccessToken","last has been unbanned"]\n' == rv.data
+        assert b'{"access_token":"RefreshToken","message":"last has been unbanned","refresh_token":"AccessToken","status_code":200}\n' == rv.data

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -36,7 +36,10 @@ def test_community_post(client):
             },
             follow_redirects=True,
         )
-        assert b'{"access_token":"RefreshToken","message":"Community Created","refresh_token":"AccessToken","status_code":200}\n' == rv.data
+        assert (
+            b'{"access_token":"RefreshToken","message":"Community Created","refresh_token":"AccessToken","status_code":200}\n'
+            == rv.data
+        )
 
 
 def test_community_get(client):
@@ -72,7 +75,10 @@ def test_community_put(client):
             },
             follow_redirects=True,
         )
-        assert b'{"access_token":"RefreshToken","message":"Community Updated","refresh_token":"AccessToken","status_code":200}\n' == rv.data
+        assert (
+            b'{"access_token":"RefreshToken","message":"Community Updated","refresh_token":"AccessToken","status_code":200}\n'
+            == rv.data
+        )
 
 
 def test_community_delete(client):
@@ -94,7 +100,10 @@ def test_community_delete(client):
             },
             follow_redirects=True,
         )
-        assert b'{"access_token":"RefreshToken","message":"Community Deleted","refresh_token":"AccessToken","status_code":200}\n' == rv.data
+        assert (
+            b'{"access_token":"RefreshToken","message":"Community Deleted","refresh_token":"AccessToken","status_code":200}\n'
+            == rv.data
+        )
 
 
 def test_community_join_post(client):
@@ -112,7 +121,10 @@ def test_community_join_post(client):
             json={"name": "Jeffery", "token": "Toke", "email": "Testemail@gmail.com"},
             follow_redirects=True,
         )
-        assert b'{"access_token":"RefreshToken","message":"Community Joined","refresh_token":"AccessToken","status_code":200}\n' == rv.data
+        assert (
+            b'{"access_token":"RefreshToken","message":"Community Joined","refresh_token":"AccessToken","status_code":200}\n'
+            == rv.data
+        )
 
 
 def test_community_leave_post(client):
@@ -130,4 +142,7 @@ def test_community_leave_post(client):
             json={"name": "Jeffery", "token": "Toke", "email": "Testemail@gmail.com"},
             follow_redirects=True,
         )
-        assert b'{"access_token":"RefreshToken","message":"Community Left","refresh_token":"AccessToken","status_code":200}\n' == rv.data
+        assert (
+            b'{"access_token":"RefreshToken","message":"Community Left","refresh_token":"AccessToken","status_code":200}\n'
+            == rv.data
+        )

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -36,7 +36,7 @@ def test_community_post(client):
             },
             follow_redirects=True,
         )
-        assert b'["RefreshToken","AccessToken","Community Created"]\n' == rv.data
+        assert b'{"access_token":"RefreshToken","message":"Community Created","refresh_token":"AccessToken","status_code":200}\n' == rv.data
 
 
 def test_community_get(client):
@@ -72,7 +72,7 @@ def test_community_put(client):
             },
             follow_redirects=True,
         )
-        assert b'["RefreshToken","AccessToken","Community Updated"]\n' == rv.data
+        assert b'{"access_token":"RefreshToken","message":"Community Updated","refresh_token":"AccessToken","status_code":200}\n' == rv.data
 
 
 def test_community_delete(client):
@@ -94,7 +94,7 @@ def test_community_delete(client):
             },
             follow_redirects=True,
         )
-        assert b'["RefreshToken","AccessToken","Community Deleted"]\n' == rv.data
+        assert b'{"access_token":"RefreshToken","message":"Community Deleted","refresh_token":"AccessToken","status_code":200}\n' == rv.data
 
 
 def test_community_join_post(client):
@@ -112,7 +112,7 @@ def test_community_join_post(client):
             json={"name": "Jeffery", "token": "Toke", "email": "Testemail@gmail.com"},
             follow_redirects=True,
         )
-        assert b'["RefreshToken","AccessToken","Community Joined"]\n' == rv.data
+        assert b'{"access_token":"RefreshToken","message":"Community Joined","refresh_token":"AccessToken","status_code":200}\n' == rv.data
 
 
 def test_community_leave_post(client):
@@ -130,4 +130,4 @@ def test_community_leave_post(client):
             json={"name": "Jeffery", "token": "Toke", "email": "Testemail@gmail.com"},
             follow_redirects=True,
         )
-        assert b'["RefreshToken","AccessToken","Community Left"]\n' == rv.data
+        assert b'{"access_token":"RefreshToken","message":"Community Left","refresh_token":"AccessToken","status_code":200}\n' == rv.data


### PR DESCRIPTION
updated the account post response, the endpoint now includes required authorization (from azure, so only purdue azure accounts can register). the endpoint also now returns a json response with the information that the account was created with. The db call now will exclude the token field