### PR TITLE
Security + decorators

### DIFF
--- a/biit_server/authentication.py
+++ b/biit_server/authentication.py
@@ -1,0 +1,56 @@
+from biit_server.http_responses import http400
+from biit_server.azure import azure_refresh_token
+from enum import Enum
+
+
+class AuthenticatedType(Enum):
+    BODY = 0
+    """
+    the token to authenticate with is located in the body 
+    of the request
+    """
+    QUERY = 1
+    """
+    the token to authenticate with is located in the query
+    parameters of the request
+    """
+    NONE = 2
+    """
+    there is no authentication for this request
+    """
+
+
+def authenticated(type: AuthenticatedType = AuthenticatedType.NONE):
+    """
+    Decorator for making sure a request is authenticated properly
+
+    Args:
+        type (AuthenticatedType): the type of authentication to use
+
+    """
+
+    def decorator(func):
+        def wrapper(request):
+            auth = None
+            if type == AuthenticatedType.BODY:
+                body = None
+                try:
+                    body = request.get_json()
+                except:
+                    return http400("Missing body")
+                auth = azure_refresh_token(body["token"])
+                print(auth, body)
+                if not auth[0]:
+                    return http400("Not Authenticated")
+            if type == AuthenticatedType.QUERY:
+                args = request.args
+                auth = azure_refresh_token(args["token"])
+                if not auth[0]:
+                    return http400("Not Authenticated")
+
+            result = func(request, auth)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/biit_server/azure.py
+++ b/biit_server/azure.py
@@ -1,3 +1,4 @@
+from biit_server.utils import mock_dev
 import requests
 import os
 from typing import Tuple
@@ -18,6 +19,7 @@ The redirect url registered with azure.
 """
 
 
+@mock_dev(("AccessToken", "RefreshToken"))
 def azure_refresh_token(refresh_token: str) -> Tuple[str, str]:
     """
     Refreshes a given refresh token and returns the
@@ -39,9 +41,6 @@ def azure_refresh_token(refresh_token: str) -> Tuple[str, str]:
                          process and obtain a new refresh token.
 
     """
-    stage = os.getenv("STAGE")
-    if stage == "dev":
-        return ("AccessToken", "RefreshToken")
 
     url = f"https://login.microsoftonline.com/{TENANT_ID}/oauth2/v2.0/token"
 
@@ -59,6 +58,7 @@ def azure_refresh_token(refresh_token: str) -> Tuple[str, str]:
     return (rjson["access_token"], rjson["refresh_token"])
 
 
+@mock_dev(True)
 def azure_validate_email(email: str, access_token: str) -> bool:
     """
     Validates that a given email and access token correspond to 
@@ -75,11 +75,6 @@ def azure_validate_email(email: str, access_token: str) -> bool:
         bool: true if the email matches the access_token and 
             false otherwise
     """
-
-    stage = os.getenv("STAGE")
-    if stage == "dev":
-        return True
-
     url = "https://graph.microsoft.com/oidc/userinfo"
     headers = {
         "Authorization": "Bearer " + access_token,

--- a/biit_server/azure.py
+++ b/biit_server/azure.py
@@ -1,6 +1,5 @@
 from biit_server.utils import mock_dev
 import requests
-import os
 from typing import Tuple
 
 CLIENT_ID = "c128fe76-dc54-4daa-993c-1a13c1e82080"
@@ -61,18 +60,18 @@ def azure_refresh_token(refresh_token: str) -> Tuple[str, str]:
 @mock_dev(True)
 def azure_validate_email(email: str, access_token: str) -> bool:
     """
-    Validates that a given email and access token correspond to 
-    the same account. 
+    Validates that a given email and access token correspond to
+    the same account.
 
-    This method should be used with validation to prevent a user 
-    from modifying another account 
+    This method should be used with validation to prevent a user
+    from modifying another account
 
     Args:
-        email (str): the email of the account that is being modified. 
-        access_token: (str): the current access token  
+        email (str): the email of the account that is being modified.
+        access_token: (str): the current access token
 
     Returns:
-        bool: true if the email matches the access_token and 
+        bool: true if the email matches the access_token and
             false otherwise
     """
     url = "https://graph.microsoft.com/oidc/userinfo"

--- a/biit_server/azure.py
+++ b/biit_server/azure.py
@@ -57,3 +57,39 @@ def azure_refresh_token(refresh_token: str) -> Tuple[str, str]:
         return ("", "")
 
     return (rjson["access_token"], rjson["refresh_token"])
+
+
+def azure_validate_email(email: str, access_token: str) -> bool:
+    """
+    Validates that a given email and access token correspond to 
+    the same account. 
+
+    This method should be used with validation to prevent a user 
+    from modifying another account 
+
+    Args:
+        email (str): the email of the account that is being modified. 
+        access_token: (str): the current access token  
+
+    Returns:
+        bool: true if the email matches the access_token and 
+            false otherwise
+    """
+
+    stage = os.getenv("STAGE")
+    if stage == "dev":
+        return True
+
+    url = "https://graph.microsoft.com/oidc/userinfo"
+    headers = {
+        "Authorization": "Bearer " + access_token,
+        "Content-Type": "application/json",
+    }
+
+    response = requests.get(url=url, headers=headers)
+    rjson = response.json()
+
+    if response.status_code != 200:
+        return False
+
+    return rjson["email"] == email

--- a/biit_server/ban_handler.py
+++ b/biit_server/ban_handler.py
@@ -1,12 +1,11 @@
-from .http_responses import http200, http400, jsonHttp200
+from biit_server.authentication import AuthenticatedType, authenticated
+from .http_responses import http400, jsonHttp200
 from .query_helper import validate_body, validate_query_params
-from .azure import azure_refresh_token
 from .database import Database
 
-from google.cloud import firestore
 
-
-def ban_post(request):
+@authenticated(AuthenticatedType.BODY)
+def ban_post(request, auth):
     """Handles the ban post endpoint
     Validates data in from the request then calls the db to ban the user
     Args:
@@ -30,12 +29,6 @@ def ban_post(request):
     # check that body validation succeeded
     if body_validation[1] != 200:
         return body_validation
-
-    auth = azure_refresh_token(body["token"])
-    if not auth[0]:
-        return http400("Not Authenticated")
-
-    # return ban.add(args)
 
     community_db = Database("communities")
     community = community_db.get(body["community"]).to_dict()
@@ -62,7 +55,8 @@ def ban_post(request):
     return jsonHttp200(body["bannee"] + " has been banned", response)
 
 
-def ban_put(request):
+@authenticated(AuthenticatedType.QUERY)
+def ban_put(request, auth):
     """Handles the ban PUT endpoint
     Validates the request and calls the db to unban the banner
 
@@ -84,10 +78,6 @@ def ban_put(request):
     # check that body validation succeeded
     if query_validation[1] != 200:
         return query_validation
-
-    auth = azure_refresh_token(args["token"])
-    if not auth[0]:
-        return http400("Not Authenticated")
 
     ban_db = Database("communities")
 

--- a/biit_server/ban_handler.py
+++ b/biit_server/ban_handler.py
@@ -1,9 +1,10 @@
 from biit_server.authentication import AuthenticatedType, authenticated
-from .http_responses import http400, jsonHttp200
-from .query_helper import validate_body, validate_query_params
+from .http_responses import jsonHttp200
+from .query_helper import ValidateType, validate_fields
 from .database import Database
 
 
+@validate_fields(["banner", "bannee", "community", "token"], ValidateType.BODY)
 @authenticated(AuthenticatedType.BODY)
 def ban_post(request, auth):
     """Handles the ban post endpoint
@@ -17,18 +18,7 @@ def ban_post(request, auth):
     Raises:
         Http 400 when the json is missing a key
     """
-    fields = ["banner", "bannee", "community", "token"]
-    body = None
-
-    try:
-        body = request.get_json()
-    except:
-        return http400("Missing body")
-
-    body_validation = validate_body(body, fields)
-    # check that body validation succeeded
-    if body_validation[1] != 200:
-        return body_validation
+    body = request.get_json()  # wont fail because validation occurs first
 
     community_db = Database("communities")
     community = community_db.get(body["community"]).to_dict()
@@ -55,6 +45,7 @@ def ban_post(request, auth):
     return jsonHttp200(body["bannee"] + " has been banned", response)
 
 
+@validate_fields(["banner", "bannee", "community", "token"], ValidateType.QUERY)
 @authenticated(AuthenticatedType.QUERY)
 def ban_put(request, auth):
     """Handles the ban PUT endpoint
@@ -69,15 +60,8 @@ def ban_put(request, auth):
     Raises:
         Http 400 when the json is missing a key
     """
-    fields = ["banner", "bannee", "community", "token"]
-
     # serializes the quert string to a dict (neeto)
-    args = request.args
-
-    query_validation = validate_query_params(args, fields)
-    # check that body validation succeeded
-    if query_validation[1] != 200:
-        return query_validation
+    args = request.args  # wont fail because validation occurs first
 
     ban_db = Database("communities")
 

--- a/biit_server/utils.py
+++ b/biit_server/utils.py
@@ -1,14 +1,16 @@
 import os
 
+
 def mock_dev(return_value):
     """
     Decorator for mocking the return value of a function when
     in a dev environment
 
     Args:
-        return_value (any): the value to have the function return  
+        return_value (any): the value to have the function return
             when run from inside a dev environment
     """
+
     def decorator(func):
         def wrapper(*args, **kwargs):
             stage = os.getenv("STAGE")

--- a/biit_server/utils.py
+++ b/biit_server/utils.py
@@ -13,7 +13,7 @@ def mock_dev(return_value):
 
     def decorator(func):
         def wrapper(*args, **kwargs):
-            stage = os.getenv("STAGE")
+            stage = os.getenv("STAGE", "dev")
             if stage == "dev":
                 return return_value
 

--- a/biit_server/utils.py
+++ b/biit_server/utils.py
@@ -1,0 +1,23 @@
+import os
+
+def mock_dev(return_value):
+    """
+    Decorator for mocking the return value of a function when
+    in a dev environment
+
+    Args:
+        return_value (any): the value to have the function return  
+            when run from inside a dev environment
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            stage = os.getenv("STAGE")
+            if stage == "dev":
+                return return_value
+
+            result = func(*args, **kwargs)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/tests/test_ban.py
+++ b/tests/test_ban.py
@@ -1,7 +1,6 @@
 import pytest
-from biit_server import create_app, ban_handler
+from biit_server import create_app
 from unittest.mock import patch
-from mockfirestore import MockFirestore
 
 
 @pytest.fixture
@@ -35,16 +34,11 @@ def test_ban_post(client):
 
 
     """
-    with patch.object(
-        ban_handler, "azure_refresh_token"
-    ) as mock_azure_refresh_token, patch(
-        "biit_server.ban_handler.Database"
-    ) as mock_database:
+    with patch("biit_server.ban_handler.Database") as mock_database:
         instance = mock_database.return_value
         instance.get.return_value = MockBanEmpty("last")
         instance.update.return_value = True
 
-        mock_azure_refresh_token.return_value = ("RefreshToken", "AccessToken")
         rv = client.post(
             "/ban",
             json={
@@ -56,7 +50,7 @@ def test_ban_post(client):
             follow_redirects=True,
         )
         assert (
-            b'{"access_token":"RefreshToken","message":"last has been banned","refresh_token":"AccessToken","status_code":200}\n'
+            b'{"access_token":"AccessToken","message":"last has been banned","refresh_token":"RefreshToken","status_code":200}\n'
             == rv.data
         )
 
@@ -67,20 +61,7 @@ def test_ban_put(client):
 
 
     """
-    with patch.object(
-        ban_handler, "azure_refresh_token"
-    ) as mock_azure_refresh_token, patch(
-        "biit_server.ban_handler.Database"
-    ) as mock_database:
-        mock_azure_refresh_token.return_value = ("RefreshToken", "AccessToken")
-
-        test_data = {
-            "banner": "first",
-            "bannee": "last",
-            "community": "com",
-            "token": "test",
-        }
-
+    with patch("biit_server.ban_handler.Database") as mock_database:
         instance = mock_database.return_value
         instance.get.return_value = MockBan({"name": "last", "ordered_by": "first"})
         instance.update.return_value = True
@@ -95,6 +76,6 @@ def test_ban_put(client):
             follow_redirects=True,
         )
         assert (
-            b'{"access_token":"RefreshToken","message":"last has been unbanned","refresh_token":"AccessToken","status_code":200}\n'
+            b'{"access_token":"AccessToken","message":"last has been unbanned","refresh_token":"RefreshToken","status_code":200}\n'
             == rv.data
         )


### PR DESCRIPTION
added a method to better validate requests (by checking email against token) and added some decorators to abstract away boilerplate request code, implemented in ban as to show how it operates. (if approved will implement everywhere else).