### PR TITLE
Basic implementation of discord error messages

### DIFF
--- a/biit_server/account_handler.py
+++ b/biit_server/account_handler.py
@@ -42,6 +42,9 @@ def account_post(request, auth):
 
         account_db.add(db_entry, id=body["email"])
     except:
+        send_discord_message(
+            f'Attempted to create an account with existing email: {body["email"]}'
+        )
         return http400("Email already taken")
 
     response = {
@@ -82,6 +85,7 @@ def account_get(request, auth):
         }
         return jsonHttp200("Account returned", response)
     except:
+        send_discord_message(f"Account with email [{args['email']}] does not exist")
         return http400("Account not found")
 
 
@@ -119,6 +123,9 @@ def account_put(request, auth):
 
     update_validation = validate_update_field(args, valid_updates)
     if update_validation[1] != 200:
+        send_discord_message(
+            f'Error updating account [{args["email"]}]: {update_validation[0]}'
+        )
         return update_validation
 
     if "schedule" in args["updateFields"]:
@@ -136,6 +143,7 @@ def account_put(request, auth):
 
         return jsonHttp200("Account Updated", response)
     except:
+        send_discord_message(f'unable to update account [{args["email"]}]')
         return http400("Account update error")
 
 
@@ -164,6 +172,7 @@ def account_delete(request, auth):
         storage.delete(args["email"] + ".jpg")
         return http200("Account deleted")
     except:
+        send_discord_message(f'Error deleting account [{args["email"]}]')
         return http400("Error in account deletion")
 
 
@@ -189,6 +198,9 @@ def profile_post(request, auth):
     try:
         profile_storage.add(file_decode, body["filename"])
     except:
+        send_discord_message(
+            f'Unable to upload file [{body["filename"]}] for account [{body["email"]}]'
+        )
         return http400("File was unable to be uploaded")
 
     response = {
@@ -226,4 +238,7 @@ def profile_get(request, auth):
 
         return jsonHttp200("File Received", response)
     except:
+        send_discord_message(
+            f'Profile image does not exist for account [{args["email"]}]'
+        )
         return http400("File not found")

--- a/biit_server/authentication.py
+++ b/biit_server/authentication.py
@@ -1,6 +1,7 @@
 from biit_server.http_responses import http400
 from biit_server.azure import azure_refresh_token
 from enum import Enum
+from biit_server.utils import send_discord_message
 
 
 class AuthenticatedType(Enum):
@@ -42,23 +43,38 @@ def authenticated(type: AuthenticatedType = AuthenticatedType.NONE):
                 try:
                     body = request.get_json()
                 except:
+                    send_discord_message(
+                        f"unable to parse body for request handler {func.__name__}"
+                    )
                     return http400("Missing body")
                 auth = azure_refresh_token(body["token"])
                 if not auth[0]:
+                    send_discord_message(
+                        f"body authentication failed for request handler {func.__name__}"
+                    )
                     return http400("Not Authenticated")
             if type == AuthenticatedType.QUERY:
                 args = request.args
                 auth = azure_refresh_token(args["token"])
                 if not auth[0]:
+                    send_discord_message(
+                        f"query authentication failed for request handler {func.__name__}"
+                    )
                     return http400("Not Authenticated")
             if type == AuthenticatedType.FORM:
                 body = None
                 try:
                     body = request.form
                 except:
+                    send_discord_message(
+                        f"unable to parse form for request handler {func.__name__}"
+                    )
                     return http400("Missing body")
                 auth = azure_refresh_token(body["token"])
                 if not auth[0]:
+                    send_discord_message(
+                        f"form authentication failed for request handler {func.__name__}"
+                    )
                     return http400("Not Authenticated")
 
             result = func(request, auth)

--- a/biit_server/feedback.py
+++ b/biit_server/feedback.py
@@ -52,3 +52,8 @@ class Feedback:
             "feedback_type": int(self.feedback_type.value),
             "feedback_status": int(self.feedback_status.value),
         }
+
+    def __str__(self):
+        return ", ".join(
+            f"[attr= {key}, value={value}]" for key, value in self.__dict__.items()
+        )

--- a/biit_server/feedback_handler.py
+++ b/biit_server/feedback_handler.py
@@ -1,3 +1,4 @@
+from biit_server.utils import send_discord_message
 from biit_server.http_responses import http400, http500, jsonHttp200
 from biit_server.feedback import Feedback
 from biit_server.database import Database
@@ -36,7 +37,10 @@ def feedback_post(request, auth):
     try:
         feedback_db.add(feedback, id=feedback_id)
     except:
-        return http500("An error occured while attempting to submit feedback")
+        return http500(
+            f"An error occured while attempting to submit feedback [{feedback}]",
+            "stephen",
+        )
 
     response = {
         "access_token": auth[0],

--- a/biit_server/http_responses.py
+++ b/biit_server/http_responses.py
@@ -9,10 +9,14 @@ def http405(method: str = ""):
 
 
 def http400(description: str):
+    send_discord_message(f"bad request: {description}")
     return f"Bad Request: {description}", 400
 
 
-def http500(description: str):
+def http500(description: str, developer: str = ""):
+    send_discord_message(
+        f'Internal Server Error: {description}. {"" if not developer else f"Endpoint developer is @{developer}"}'
+    )
     return f"Internal Server Error: {description}", 500
 
 

--- a/biit_server/meeting_handler.py
+++ b/biit_server/meeting_handler.py
@@ -1,4 +1,5 @@
 import ast
+from biit_server.utils import send_discord_message
 import json
 from biit_server.authentication import AuthenticatedType, authenticated
 import random
@@ -54,6 +55,7 @@ def meeting_post(request, auth):
     try:
         meeting_db.add(meeting, id=random_id)
     except:
+        send_discord_message(f"Meeting with id [{random_id}] is already in use")
         return http400("Meeting id already taken")
 
     response = {
@@ -99,6 +101,7 @@ def meeting_get(request, auth):
         }
         return jsonHttp200("Meeting retrieved", response)
     except:
+        send_discord_message(f'Meeting with id [{args["id"]}] does not exist')
         return http400("Meeting not found")
 
 
@@ -164,6 +167,7 @@ def meeting_delete(request, auth):
         response = {"access_token": auth[0], "refresh_token": auth[1]}
         return jsonHttp200("Meeting deleted", response)
     except:
+        send_discord_message(f'Error deleting meeting with id [{args["id"]}]')
         return http400("Meeting deletion error")
 
 

--- a/biit_server/query_helper.py
+++ b/biit_server/query_helper.py
@@ -1,3 +1,4 @@
+from biit_server.utils import send_discord_message
 from .http_responses import http200, http400
 import json
 import re
@@ -101,11 +102,17 @@ def validate_fields(fields: List[str], type: ValidateType = ValidateType.NONE):
                 try:
                     body = request.get_json()
                 except:
+                    send_discord_message(
+                        f"unable to parse body for request handler {func.__name__}"
+                    )
                     return http400("Missing body")
 
                 body_validation = validate_body(body, fields)
                 # check that body validation succeeded
                 if body_validation[1] != 200:
+                    send_discord_message(
+                        f"body validation failed for request handler {func.__name__}. {body_validation[0]}"
+                    )
                     return body_validation
 
             if type == ValidateType.QUERY:
@@ -113,6 +120,9 @@ def validate_fields(fields: List[str], type: ValidateType = ValidateType.NONE):
                 query_validation = validate_query_params(args, fields)
                 # check that body validation succeeded
                 if query_validation[1] != 200:
+                    send_discord_message(
+                        f"query validation failed for request handler {func.__name__}. {query_validation[0]}"
+                    )
                     return query_validation
 
             if type == ValidateType.FORM:
@@ -120,11 +130,17 @@ def validate_fields(fields: List[str], type: ValidateType = ValidateType.NONE):
                 try:
                     body = request.form
                 except:
+                    send_discord_message(
+                        f"unable to parse form for request handler {func.__name__}"
+                    )
                     return http400("Missing body")
 
                 body_validation = validate_body(body, fields)
                 # check that body validation succeeded
                 if body_validation[1] != 200:
+                    send_discord_message(
+                        f"form validation failed for request handler {func.__name__}. {body_validation[0]}"
+                    )
                     return body_validation
 
             result = func(request)

--- a/biit_server/rating_handler.py
+++ b/biit_server/rating_handler.py
@@ -1,5 +1,6 @@
+from biit_server.utils import send_discord_message
 from biit_server.authentication import AuthenticatedType, authenticated
-from .http_responses import http400, jsonHttp200
+from .http_responses import http400, http500, jsonHttp200
 from .query_helper import (
     ValidateType,
     validate_fields,
@@ -81,7 +82,7 @@ def rating_get(request, auth):
     rating_db_response = rating_db.get(args["meeting_id"])
 
     if not rating_db_response:
-        return http400(f"Error in retrieving rating from Firestore database.")
+        return http500(f"Error in retrieving rating from Firestore database.", "Lucas")
 
     rating = Rating(document_snapshot=rating_db_response)
 
@@ -93,4 +94,5 @@ def rating_get(request, auth):
         }
         return jsonHttp200("Rating Received", response)
     except:
+        send_discord_message(f'Rating with id [{args["meeting_id"]}] does not exist')
         return http400("Rating not found")

--- a/biit_server/utils.py
+++ b/biit_server/utils.py
@@ -59,6 +59,7 @@ def send_discord_message(message: str):
     webhook = os.getenv("DISCORD_BOT", None)
     if webhook == None:
         logging.critical("Unable to read webhook from environment variable")
+        return
 
     response = requests.post(webhook, json={"content": message})
 


### PR DESCRIPTION
This includes a lot of discord messages, I'm guessing there are some errors in messages being sent twice or not sent at all but this is a first iteration. I think merging it in now and then updating messages from errors we experience in developing should help. I also think we abuse `http400` when we should be sending `http500` so I advise you check your specific endpoints and make sure all errors are defined correctly to your knowledge.

P.S. once this is integrated I can imagine the `#loggers` chat will become very active