### PR TITLE
(Thursday) Turned schedule into single list

### DIFF
--- a/biit_server/account_handler.py
+++ b/biit_server/account_handler.py
@@ -133,11 +133,13 @@ def account_put(request, auth):
 
     if "schedule" in args["updateFields"]:
         temp_schedule = [
-            [int(item[0]), int(item[1])]
-            for item in ast.literal_eval(args["updateFields"])["schedule"]
+            int(item)
+            for tup in ast.literal_eval(args["updateFields"])["schedule"]
+            for item in tup
         ]
-        
-        account_db.update(args["email"], {"schedule": temp_schedule})
+
+        if not account_db.update(args["email"], {"schedule": temp_schedule}):
+            send_discord_message(f"Error updating account schedule {temp_schedule}")
 
     try:
         account_db.update(args["email"], ast.literal_eval(args["updateFields"]))


### PR DESCRIPTION
A rework to schedule as firestore doesn't store arrays of arrays. Instead, it becomes a single long list with every two indexes being someone's availability. To note this can affect time matching, but that will be handled when it is added to matching.