### PR TITLE
Updated put route to regulate changes to an community only if they are in the admin list

### DIFF
--- a/biit_server/community_handler.py
+++ b/biit_server/community_handler.py
@@ -100,6 +100,10 @@ def community_put(request, auth):
     args = request.args
 
     community_db = Database("communities")
+    community = community_db.get(args["name"]).to_dict()
+
+    if args["email"] not in community["Admins"]:
+        return http401(f'{args["email"]} is not an admin of {args["name"]}')
 
     community_db.update(args["name"], ast.literal_eval(args["updateFields"]))
     response = {
@@ -170,7 +174,8 @@ def community_join_post(request, community_id):
 
     auth = azure_refresh_token(body["token"])
     if not auth[0]:
-        send_discord_message(f"body authentication failed for account {body['email']}")
+        send_discord_message(
+            f"body authentication failed for account {body['email']}")
         return http401("Not Authenticated")
 
     community_db = Database("communities")
@@ -228,14 +233,16 @@ def community_leave_post(request, community_id):
 
     auth = azure_refresh_token(body["token"])
     if not auth[0]:
-        send_discord_message(f"body authentication failed for account {body['email']}")
+        send_discord_message(
+            f"body authentication failed for account {body['email']}")
         return http401("Not Authenticated")
 
     community_db = Database("communities")
     community = community_db.get(community_id).to_dict()
     community_db.update(
         community_id,
-        {"Members": [user for user in community["Members"] if user != body["email"]]},
+        {"Members": [user for user in community["Members"]
+                     if user != body["email"]]},
     )
     response = {
         "access_token": auth[0],

--- a/biit_server/community_handler.py
+++ b/biit_server/community_handler.py
@@ -174,8 +174,7 @@ def community_join_post(request, community_id):
 
     auth = azure_refresh_token(body["token"])
     if not auth[0]:
-        send_discord_message(
-            f"body authentication failed for account {body['email']}")
+        send_discord_message(f"body authentication failed for account {body['email']}")
         return http401("Not Authenticated")
 
     community_db = Database("communities")
@@ -233,16 +232,14 @@ def community_leave_post(request, community_id):
 
     auth = azure_refresh_token(body["token"])
     if not auth[0]:
-        send_discord_message(
-            f"body authentication failed for account {body['email']}")
+        send_discord_message(f"body authentication failed for account {body['email']}")
         return http401("Not Authenticated")
 
     community_db = Database("communities")
     community = community_db.get(community_id).to_dict()
     community_db.update(
         community_id,
-        {"Members": [user for user in community["Members"]
-                     if user != body["email"]]},
+        {"Members": [user for user in community["Members"] if user != body["email"]]},
     )
     response = {
         "access_token": auth[0],

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -43,11 +43,11 @@ class MockCollectionLeave:
 
 
 class MockCommunity:
-    def __init__(self, name):
-        self.name = name
+    def __init__(self, data):
+        self.data = data
 
     def to_dict(self):
-        return {"name": self.name}
+        return self.data
 
 
 def test_community_post(client):
@@ -62,7 +62,7 @@ def test_community_post(client):
             "name": "TestCommunity",
         }
 
-        instance.get.return_value = MockCommunity(query_data["name"])
+        instance.get.return_value = MockCommunity(query_data)
 
         test_json = {
             "name": "Cool Community",
@@ -101,7 +101,7 @@ def test_community_get(client):
             "name": "TestCommunity",
         }
 
-        instance.get.return_value = MockCommunity(query_data["name"])
+        instance.get.return_value = MockCommunity(query_data)
 
         rv = client.get(
             "/community",
@@ -124,11 +124,9 @@ def test_community_put(client):
     with patch("biit_server.community_handler.Database") as mock_database:
         instance = mock_database.return_value
         instance.update.return_value = True
-        query_data = {
-            "name": "TestCommunity",
-        }
+        query_data = {"name": "TestCommunity", "Admins": ["Testemail@gmail.com"]}
 
-        instance.get.return_value = MockCommunity(query_data["name"])
+        instance.get.return_value = MockCommunity(query_data)
         test_json = {
             "name": "TestCommunity",
             "token": "TestToken",
@@ -142,7 +140,7 @@ def test_community_put(client):
             follow_redirects=True,
         )
         assert (
-            b'{"access_token":"AccessToken","data":{"name":"TestCommunity"},"message":"Community Updated","refresh_token":"RefreshToken","status_code":200}\n'
+            b'{"access_token":"AccessToken","data":{"Admins":["Testemail@gmail.com"],"name":"TestCommunity"},"message":"Community Updated","refresh_token":"RefreshToken","status_code":200}\n'
             == rv.data
         )
 

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -236,3 +236,31 @@ def test_community_leave_post(client):
 
         instance.get.assert_called_with(test_id)
         instance.update.assert_called_once_with(test_id, {"Members": []})
+
+
+def test_community_put_badadmin(client):
+    """
+    Tests that community put works correctly
+    """
+    with patch("biit_server.community_handler.Database") as mock_database:
+        instance = mock_database.return_value
+        instance.update.return_value = True
+        query_data = {"name": "TestCommunity", "Admins": ["Badmin@admin.com"]}
+
+        instance.get.return_value = MockCommunity(query_data)
+        test_json = {
+            "name": "TestCommunity",
+            "token": "TestToken",
+            "email": "Testemail@gmail.com",
+            "updateFields": {"name": "lanes"},
+        }
+
+        rv = client.put(
+            "/community",
+            query_string=test_json,
+            follow_redirects=True,
+        )
+        assert (
+            b"UnAuthorized: Testemail@gmail.com is not an admin of TestCommunity"
+            == rv.data
+        )


### PR DESCRIPTION
This allows for admins of a community to make changes to a community and to add users as admins, U-47