### PR TITLE
Community stats

### DIFF
--- a/biit_server/app.py
+++ b/biit_server/app.py
@@ -39,6 +39,7 @@ from .meeting_handler import (
 )
 
 from .feedback_handler import feedback_delete, feedback_get, feedback_post
+from .community_stats_handler import community_stats_get
 
 # This runs on Firebase/Cloud Run!
 
@@ -85,6 +86,11 @@ def create_app():
     def leave_route(id):
         if request.method == "POST":
             return community_leave_post(request, id)
+
+    @app.route("/community/<id>/stats", methods=["GET"])
+    def stat_route(id):
+        if request.method == "GET":
+            return community_stats_get(request, id)
 
     @app.route("/ban", methods=["POST", "PUT"])
     def ban_route():

--- a/biit_server/app.py
+++ b/biit_server/app.py
@@ -92,7 +92,7 @@ def create_app():
     def stat_route(id):
         if request.method == "GET":
             return community_stats_get(request, id)
-          
+
     @app.route("/community/all", methods=["GET"])
     def community_all():
         if request.method == "GET":

--- a/biit_server/community_handler.py
+++ b/biit_server/community_handler.py
@@ -32,11 +32,21 @@ def community_post(request, auth):
     body = request.get_json()
 
     community_db = Database("communities")
+    community_stat_db = Database("community_stats")
 
     body["bans"] = []
 
     try:
         community_db.add(body, id=body["name"])
+        community_stat_db.add(
+            {
+                "accepted_meetups": 0,
+                "total_meetups": 0,
+                "total_sessions": 0,
+                "community": body["name"],
+            },
+            id=body["name"],
+        )
     except:
         send_discord_message(
             f'Attempted to create a community with an existing name [{body["name"]}]'

--- a/biit_server/community_stats.py
+++ b/biit_server/community_stats.py
@@ -1,0 +1,36 @@
+from enum import Enum
+from typing import Any, Dict, List
+
+
+class CommunityStats:
+    def __init__(
+        self,
+        user_list={},
+        community=None,
+        # this is defined as a meetup where at least
+        # 2 of the participants accepted.
+        accepted_meetups=None,
+        total_meetups=None,
+        total_sessions=None,
+        document_snapshot=None,
+    ):
+        if document_snapshot != None:
+            document_dict = document_snapshot.to_dict()
+            community = document_dict["community"]
+            accepted_meetups = document_dict["accepted_meetups"]
+            total_meetups = document_dict["total_meetups"]
+            total_sessions = document_dict["total_sessions"]
+
+        self.user_list = user_list
+        self.community = community
+        self.accepted_meetups = accepted_meetups
+        self.total_meetups = total_meetups
+        self.total_sessions = total_sessions
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "community": self.community,
+            "accepted_meetups": self.accepted_meetups,
+            "total_meetups": self.total_meetups,
+            "total_sessions": self.total_sessions,
+        }

--- a/biit_server/community_stats.py
+++ b/biit_server/community_stats.py
@@ -6,6 +6,7 @@ class CommunityStats:
     def __init__(
         self,
         user_list={},
+        # this is the community id
         community=None,
         # this is defined as a meetup where at least
         # 2 of the participants accepted.

--- a/biit_server/community_stats_handler.py
+++ b/biit_server/community_stats_handler.py
@@ -6,7 +6,7 @@ from biit_server.http_responses import http401, jsonHttp200
 
 def community_stats_get(request, community_id):
     """"""
-    fields = ["email", "token"]
+    fields = ["token"]
 
     # serializes the quert string to a dict (neeto)
     args = request.args

--- a/biit_server/community_stats_handler.py
+++ b/biit_server/community_stats_handler.py
@@ -1,0 +1,31 @@
+from biit_server.database import Database
+from biit_server.azure import azure_refresh_token
+from biit_server.query_helper import validate_query_params
+from biit_server.http_responses import http401, jsonHttp200
+
+
+def community_stats_get(request, community_id):
+    """"""
+    fields = ["email", "token"]
+
+    # serializes the quert string to a dict (neeto)
+    args = request.args
+
+    query_validation = validate_query_params(args, fields)
+    # check that body validation succeeded
+    if query_validation[1] != 200:
+        return query_validation
+
+    auth = azure_refresh_token(args["token"])
+    if not auth[0]:
+        return http401("Not Authenticated")
+
+    community_stats_db = Database("community_stats")
+
+    response = {
+        "access_token": auth[0],
+        "refresh_token": auth[1],
+        "data": community_stats_db.get(community_id).to_dict(),
+    }
+
+    return jsonHttp200("Community Stats Received", response)

--- a/biit_server/meeting.py
+++ b/biit_server/meeting.py
@@ -31,6 +31,7 @@ class Meeting:
         duration=0,
         location=None,
         meeting_type=None,
+        community=None,
         document_snapshot=None,
     ):
         if document_snapshot != None:
@@ -41,6 +42,7 @@ class Meeting:
             duration = document_dict["duration"]
             location = document_dict["location"]
             meeting_type = document_dict["meettype"]
+            community = document_dict["community"]
 
         self.user_list = user_list
         self.id = id
@@ -48,6 +50,7 @@ class Meeting:
         self.duration = duration
         self.location = location
         self.meeting_type = meeting_type
+        self.community = community
 
     def add_user(self, user) -> Dict[str, bool]:
         self.user_list[user] = 0
@@ -76,4 +79,5 @@ class Meeting:
             "user_list": self.user_list,
             "location": self.location,
             "meettype": self.meeting_type,
+            "community": self.community,
         }

--- a/biit_server/meeting_handler.py
+++ b/biit_server/meeting_handler.py
@@ -807,7 +807,6 @@ def matchup(request, auth):
             send_discord_message(f"Rating with id [{random_id}] is already in use")
             return http400("Rating id already taken")
 
-    print(meeting_list)
 
     try:
         community_stat_db.update(

--- a/biit_server/meeting_handler.py
+++ b/biit_server/meeting_handler.py
@@ -824,8 +824,7 @@ def matchup(request, auth):
             f"Error updating community stats for community [{community['id']}]"
         )
         #! No error message is generated because the community still has the meetups generated properly
-                             
-                             
+
     response = {
         "access_token": auth[0],
         "refresh_token": auth[1],

--- a/biit_server/rating.py
+++ b/biit_server/rating.py
@@ -7,11 +7,14 @@ class RatingAlreadySetException(Exception):
 
 
 class Rating:
-    def __init__(self, meeting_id=None, document_snapshot=None, rating_dict=None):
+    def __init__(
+        self, meeting_id=None, document_snapshot=None, rating_dict=None, community=None
+    ):
         """
         Args:
             meeting_id: int -> the ID of the meetup
             rating_dict: Dict[str, int] -> user is key, number of stars is value
+            community: str -> the ID of the community that generated this rating
             document_snapshot: google.cloud.firestore_v1.document.DocumentSnapshot ->
                 Just in case it is easier to send in the document snapshot
                 from Firestore
@@ -21,12 +24,18 @@ class Rating:
             document_data = document_snapshot.to_dict()
             meeting_id = document_data.get("meeting_id")
             rating_dict = document_data.get("rating_dict")
+            community = document_data.get("community")
 
         self.meeting_id = meeting_id
         self.rating_dict = {} if rating_dict == None else rating_dict
+        self.community = community
 
     def to_dict(self):
-        return {"meeting_id": self.meeting_id, "rating_dict": self.rating_dict}
+        return {
+            "meeting_id": self.meeting_id,
+            "rating_dict": self.rating_dict,
+            "community": self.community,
+        }
 
     def set_rating(self, user: str, rating: int) -> Dict[str, int]:
         self.rating_dict[user] = rating
@@ -38,3 +47,6 @@ class Rating:
 
     def get_meeting_id(self) -> Dict[str, int]:
         return self.meeting_id
+
+    def get_commnuity(self) -> str:
+        return self.community

--- a/biit_server/rating_handler.py
+++ b/biit_server/rating_handler.py
@@ -11,7 +11,9 @@ from .database import Database
 from .rating import Rating, RatingAlreadySetException
 
 
-@validate_fields(["meeting_id", "user", "rating", "token"], ValidateType.BODY)
+@validate_fields(
+    ["meeting_id", "user", "rating", "community", "token"], ValidateType.BODY
+)
 @authenticated(AuthenticatedType.BODY)
 def rating_post(request, auth):
     """Handles the rating POST endpoint
@@ -28,12 +30,16 @@ def rating_post(request, auth):
     body = request.get_json()
 
     rating_db = Database("ratings")
+    community_db = Database("communities")
+    community = community_db.get(body["community"]).to_dict()
 
     rating_snapshot = rating_db.get(body["meeting_id"])
 
     if rating_snapshot == False:
         rating = Rating(
-            meeting_id=body["meeting_id"], rating_dict={body["user"]: body["rating"]}
+            meeting_id=body["meeting_id"],
+            rating_dict={body["user"]: body["rating"]},
+            community=community["id"],
         )
 
         success = rating_db.add(rating.to_dict(), id=body["meeting_id"])

--- a/tests/test_community.py
+++ b/tests/test_community.py
@@ -1,6 +1,6 @@
 import pytest
 from biit_server import create_app, community_handler
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 # Waiting on DB before adding tests
 
@@ -74,6 +74,13 @@ def test_community_post(client):
             "token": "TestToken",
         }
 
+        stat_json = {
+            "community": "Cool Community",
+            "accepted_meetups": 0,
+            "total_meetups": 0,
+            "total_sessions": 0,
+        }
+
         rv = client.post(
             "/community",
             json=test_json,
@@ -86,7 +93,13 @@ def test_community_post(client):
 
         test_json["bans"] = []
 
-        instance.add.assert_called_once_with(test_json, id=test_json["name"])
+        instance.add.assert_has_calls(
+            [
+                call(test_json, id=test_json["name"]),
+                call(stat_json, id=stat_json["community"]),
+            ],
+            any_order=True,
+        )
 
 
 def test_community_get(client):

--- a/tests/test_community_stats.py
+++ b/tests/test_community_stats.py
@@ -1,0 +1,66 @@
+from biit_server.app import create_app
+from unittest.mock import patch
+import pytest
+from biit_server import community_stats_handler
+import json
+
+
+@pytest.fixture
+def client():
+    cli = create_app()
+    cli.config["TESTING"] = True
+    with cli.test_client() as client:
+        yield client
+
+
+class MockCollection:
+    def __init__(self):
+        """Helper class to simulate a collection"""
+        self.community = "Johnson"
+        self.accepted_meetups = 0
+        self.total_meetups = 0
+        self.total_sessions = 0
+
+    def to_dict(self):
+        """Returns a mock collection entry"""
+        return {
+            "community": self.community,
+            "accepted_meetups": self.accepted_meetups,
+            "total_meetups": self.total_meetups,
+            "total_sessions": self.total_sessions,
+        }
+
+
+def test_community_stats_get(client):
+    """Tests that that get community stats endpoint works correctly"""
+    with patch.object(
+        community_stats_handler, "azure_refresh_token"
+    ) as mock_azure_refresh_token, patch(
+        "biit_server.community_stats_handler.Database"
+    ) as mock_database:
+        instance = mock_database.return_value
+        instance.get.return_value = MockCollection()
+        instance.update.return_value = True
+
+        test_json = {"token": "Toke", "email": "Testemail@gmail.com"}
+        test_id = "Johnson"
+
+        mock_azure_refresh_token.return_value = ("AccessToken", "RefreshToken")
+        rv = client.get(
+            f"/community/{test_id}/stats",
+            query_string=test_json,
+            follow_redirects=True,
+        )
+
+        return_data = json.loads(rv.data.decode())
+
+        assert return_data["access_token"] == "AccessToken"
+        assert return_data["data"]["community"] == "Johnson"
+        assert return_data["data"]["accepted_meetups"] == 0
+        assert return_data["data"]["total_meetups"] == 0
+        assert return_data["data"]["total_sessions"] == 0
+        assert return_data["message"] == "Community Stats Received"
+        assert return_data["refresh_token"] == "RefreshToken"
+        assert return_data["status_code"] == 200
+
+        instance.get.assert_called_with(test_id)

--- a/tests/test_meeting.py
+++ b/tests/test_meeting.py
@@ -48,9 +48,10 @@ class MockCollectionLeave:
 class MockCommunity:
     def __init__(self, name):
         self.name = name
+        self.id = "communityid"
 
     def to_dict(self):
-        return {"name": self.name}
+        return {"name": self.name, "id": self.id}
 
 
 def test_meeting_post(client):
@@ -64,11 +65,15 @@ def test_meeting_post(client):
             "user_list": {"paimon@purdue.edu": 0, "traveller@purdue.edu": 0},
             "meettype": "chance_meeting",
             "duration": 30,
+            "community": "jahnsens",
             "token": "TestToken",
         }
 
         instance = mock_database.return_value
         instance.add.return_value = True
+        instance.get.side_effect = (
+            lambda x: MockCommunity("jahnsens") if x == "jahnsens" else True
+        )
 
         rv = client.post(
             "/meeting",
@@ -84,6 +89,7 @@ def test_meeting_post(client):
         assert return_data["data"]["location"] == test_json["location"]
         assert return_data["data"]["meettype"] == test_json["meettype"]
         assert return_data["data"]["user_list"] == test_json["user_list"]
+        assert return_data["data"]["community"] == "communityid"
         assert return_data["message"] == "Meeting created"
         assert return_data["refresh_token"] == "RefreshToken"
         assert return_data["status_code"] == 200
@@ -896,6 +902,7 @@ def test_meeting_get_past_none(client):
             "location": "Li Yue",
             "meettype": "Gacha",
             "timestamp": datetime.now().replace(tzinfo=timezone.utc).timestamp() + 100,
+            "community": "jahnsens",
         }
 
         # print(type(test_json["timestamp"]))
@@ -907,6 +914,7 @@ def test_meeting_get_past_none(client):
             location=test_json["location"],
             meeting_type=test_json["meettype"],
             timestamp=test_json["timestamp"],
+            community=test_json["community"],
         )
 
         rv = client.get(

--- a/tests/test_meeting_algo.py
+++ b/tests/test_meeting_algo.py
@@ -95,6 +95,7 @@ def test_meeting_algo(client):
             ),
             "Purdue Exponent": MockCommunity(
                 {
+                    "id": "Purdue Exponent",
                     "Admins": ["ryan@purdue.edu"],
                     "Members": ["ryan@purdue.edu", "alisa@purdue.edu"],
                 }
@@ -174,6 +175,7 @@ def test_meeting_algo_filter_opt_out(client):
             ),
             "Purdue Exponent": MockCommunity(
                 {
+                    "id": "Purdue Exponent",
                     "Admins": ["ryan@purdue.edu"],
                     "Members": [
                         "ryan@purdue.edu",
@@ -258,6 +260,7 @@ def test_meeting_algo_different_preferences(client):
             ),
             "Purdue Exponent": MockCommunity(
                 {
+                    "id": "Purdue Exponent",
                     "Admins": ["ryan@purdue.edu"],
                     "Members": [
                         "ryan@purdue.edu",


### PR DESCRIPTION
## Overview
This is a big one. here is a list of what I did then followed by a list of what wasn't done.

## What was done
- added community ID to rating and meetup models
- added community stats model
- updated matchup algorithm to update community statistics when called
- updated accept and decline endpoints to update community statistics when called
- added endpoint for getting community statistics
- tested endpoint for getting community statistics

## What wasn't done
- tested community statistics were updated properly 
- update wiki (will do so after this is approved)
  - update rating wiki (model returned includes community now)
  - update meeting wiki (model returned includes community now)
  - create community stat wiki (very similar to join/leave)

I have not tested that statistics are updated properly because that requires I make some very complex unit tests for it since it occurs in another endpoint. I think it would be best to upgrade our testing infrastructure before doing so. That would make things easier. Please leave feedback and we can discuss further at todays meeting.
