### PR TITLE
Added endpoint to get previous users

### DIFF
--- a/biit_server/app.py
+++ b/biit_server/app.py
@@ -34,6 +34,7 @@ from .meeting_handler import (
     meeting_accept,
     meeting_decline,
     meetings_get_all,
+    meetings_get_past_users,
     meetings_get_pending,
     meetings_get_upcoming,
     meetings_get_past,
@@ -167,6 +168,11 @@ def create_app():
     def meeting_user_past_fetch_route():
         if request.method == "GET":
             return meetings_get_past(request)
+
+    @app.route("/meeting/past/users", methods=["GET"])
+    def meeting_get_past_users_route():
+        if request.method == "GET":
+            return meetings_get_past_users(request)
 
     @app.route("/meeting/reschedule", methods=["POST"])
     def meeting_reschedule_route():

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,5 @@ deps =
 	pytest-mock
 	-rrequirements.txt
 commands =
-	pytest -v
+	pytest -vv
 	black tests biit_server


### PR DESCRIPTION
added endpoint to get previous users `meeting/past/users` this takes in just an `email` and `token` and returns a list of previous users as requested @DanielKambich 